### PR TITLE
Remove phone number from CV

### DIFF
--- a/data/cv.yaml
+++ b/data/cv.yaml
@@ -2,7 +2,6 @@ name: Bogdan Novosad
 role: "SWE | .NET, AWS, RAG, Agentic Coding"
 contact:
   email: bogdan@sacrorum.com
-  phone: "+34 685 564 571"
   website: https://sacrorum.com/
   linkedin: https://www.linkedin.com/in/novosad/
   location: Spain


### PR DESCRIPTION
### Motivation
- Remove the personal phone number from the CV data to protect privacy and keep contact information minimal.

### Description
- Deleted the `phone` field from `data/cv.yaml` under the `contact` section.

### Testing
- No automated tests were run because this is a content-only change and the CV template already guards the phone rendering with `{{- with $cv.contact.phone }}` so no rendering errors are expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d421d7c4832ea99febb905dbfe4f)